### PR TITLE
Drop target selector now uses closest() so it works better in a listview

### DIFF
--- a/src/DragAndDropSupportWidget/widget/DroppableWidget.js
+++ b/src/DragAndDropSupportWidget/widget/DroppableWidget.js
@@ -49,7 +49,7 @@ require( [
             }
             var node;
             if (this.dropTargetSelector) {
-                node = $(this.dropTargetSelector);
+                node = $(this.domNode).closest(this.dropTargetSelector);
             } else {
                 node = $(this.domNode.parentElement);
             }


### PR DESCRIPTION
Using closest(), you can target '.listview-item' and put the widget in the listview content.
It will now grab it's nearest listview-item (its own container) to mark it as a drop target.